### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,4 +1,6 @@
 name: Version Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ghotso/HAS-pCloud-Backup/security/code-scanning/1](https://github.com/ghotso/HAS-pCloud-Backup/security/code-scanning/1)

To fix this issue, you should add a `permissions` block either at the workflow root or at the job level for `version-check`. The safest and simplest way, given this workflow only checks code, is to set the root-level `permissions: contents: read`, which restricts the GITHUB_TOKEN to read-only access to repository contents. This is done by adding the following lines to the top of your workflow file right after the `name:` entry and before the `on:` section. No library imports or other code changes are required, only the addition of the permissions block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add read-only `permissions: contents: read` to the `version-check` workflow.
> 
> - **CI / GitHub Actions**:
>   - Add root-level `permissions` block in `.github/workflows/version-check.yml` with `contents: read`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87e2351cfde3df39f9970dc8d1959bb31a4f9a5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->