### PR TITLE
docs(README): update sensor descriptions and add new space metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The integration provides the following sensors:
 - `sensor.pcloud_remote_backup_count` - Number of backups stored in pCloud
 - `sensor.pcloud_last_remote_backup` - Timestamp of the last successful backup upload
 - `sensor.pcloud_last_sync_status` - Status of the last sync operation (OK/Failed)
+- `sensor.pcloud_free_space` - Free space available in your pCloud account (account-wide quota)
+- `sensor.pcloud_used_space_by_backups` - Storage used by your Home Assistant backups in the pCloud backup folder
+- `sensor.pcloud_account_used_space` - Total storage used across your entire pCloud account
 
 ## Usage
 


### PR DESCRIPTION
- Added descriptions for new sensors: `sensor.pcloud_free_space`, `sensor.pcloud_used_space_by_backups`, and `sensor.pcloud_account_used_space`.
- Enhanced the README to provide clearer information on available sensors in the pCloud backup integration.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds sensor descriptions; no runtime or integration behavior is modified.
> 
> **Overview**
> Updates `README.md` to document three additional sensors that report pCloud storage metrics: `sensor.pcloud_free_space`, `sensor.pcloud_used_space_by_backups`, and `sensor.pcloud_account_used_space`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8a9da25691787c5ebb30d5700a7ec95fcc70b5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->