### PR TITLE
Enhance OAuth2 handling, upload timeout, and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,153 +1,365 @@
+# Automated release when custom_components/pcloud_backup/manifest.json version on main
+# is greater than the latest v* tag and no tag exists yet for that version.
+#
+# Creates: git tag vX.Y.Z, GitHub Draft Release (notes + pcloud_backup.zip).
+# You publish the draft on GitHub when ready — that makes the release public.
+#
+# Optional: set repository secret GH_TOKEN (fine-grained PAT: contents read/write,
+# metadata read) if GITHUB_TOKEN cannot push tags or create releases (e.g. branch rules).
+# Optional: OPENAI_API_TOKEN — drafts user-facing release notes from integration-only
+# commits (under custom_components/pcloud_backup/). Excludes workflow/CI-only changes.
+
 name: Release
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version number (e.g., 0.1.0, 1.2.3)'
-        required: true
-        type: string
 
 permissions:
   contents: write
 
+concurrency:
+  group: release-automation
+  cancel-in-progress: false
+
 jobs:
   release:
-    name: Release
+    name: Version check, tag, release, and zip
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GH_TOKEN || github.token }}
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install python-semantic-release
+      - name: Evaluate manifest vs latest tag and prepare release
+        id: plan
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          OPENAI_API_TOKEN: ${{ secrets.OPENAI_API_TOKEN }}
         run: |
-          pip install python-semantic-release[changelog]>=9.0.0
+          set -euo pipefail
+          pip install --quiet packaging
+          python3 << 'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
 
-      - name: Validate version format
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9-]+(\.[0-9]+)?)?$'; then
-            echo "❌ Invalid version format: $VERSION"
-            echo "Version must follow SemVer format: MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-PRERELEASE"
-            exit 1
-          fi
-          echo "✅ Version format is valid: $VERSION"
+          from packaging.version import InvalidVersion, Version
 
-      - name: Configure git
+          def run(cmd: list[str]) -> str:
+              return subprocess.check_output(cmd, text=True).strip()
+
+          def latest_version_tag() -> str | None:
+              try:
+                  out = run(
+                      [
+                          "git",
+                          "tag",
+                          "-l",
+                          "v*",
+                          "--sort=-v:refname",
+                      ]
+                  )
+              except subprocess.CalledProcessError:
+                  return None
+              lines = [ln for ln in out.splitlines() if ln.strip()]
+              if not lines:
+                  return None
+              for tag in lines:
+                  m = re.match(r"^v(.+)$", tag)
+                  if not m:
+                      continue
+                  try:
+                      Version(m.group(1))
+                      return tag
+                  except InvalidVersion:
+                      continue
+              return lines[0]
+
+          def tag_exists(tag: str) -> bool:
+              try:
+                  run(["git", "rev-parse", tag])
+                  return True
+              except subprocess.CalledProcessError:
+                  return False
+
+          with open("custom_components/pcloud_backup/manifest.json", encoding="utf-8") as f:
+              manifest = json.load(f)
+          manifest_version = str(manifest.get("version", "")).strip()
+          if not manifest_version:
+              print("::error::manifest.json has no version")
+              sys.exit(1)
+
+          try:
+              mv = Version(manifest_version)
+          except InvalidVersion as e:
+              print(f"::error::Invalid semver in manifest: {manifest_version!r} ({e})")
+              sys.exit(1)
+
+          latest_tag = latest_version_tag()
+          if latest_tag:
+              m = re.match(r"^v(.+)$", latest_tag)
+              lv = Version(m.group(1)) if m else Version("0")
+          else:
+              lv = Version("0")
+
+          new_tag = f"v{manifest_version}"
+
+          if mv <= lv:
+              print(f"No release: manifest {manifest_version} is not greater than latest tag {latest_tag or 'none'}.")
+              with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as gh:
+                  gh.write("should_release=false\n")
+              sys.exit(0)
+
+          if tag_exists(new_tag):
+              print(f"No release: tag {new_tag} already exists (manifest bump only?).")
+              with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as gh:
+                  gh.write("should_release=false\n")
+              sys.exit(0)
+
+          range_ref = f"{latest_tag}..HEAD" if latest_tag else ""
+          log_rev: list[str] = [f"{latest_tag}..HEAD"] if latest_tag else []
+          rev_list_range: list[str] = [f"{latest_tag}..HEAD"] if latest_tag else ["HEAD"]
+
+          def git_output(cmd: list[str]) -> str:
+              try:
+                  return subprocess.check_output(cmd, text=True).strip()
+              except subprocess.CalledProcessError:
+                  return ""
+
+          integration_path = "custom_components/pcloud_backup"
+          integration_log = git_output(
+              [
+                  "git",
+                  "log",
+                  *log_rev,
+                  "--no-merges",
+                  "-n",
+                  "500",
+                  "--pretty=format:- %s (%h)",
+                  "--",
+                  integration_path,
+              ]
+          )
+
+          all_count_s = git_output(
+              ["git", "rev-list", "--count", "--no-merges", *rev_list_range]
+          )
+          int_count_s = git_output(
+              [
+                  "git",
+                  "rev-list",
+                  "--count",
+                  "--no-merges",
+                  *rev_list_range,
+                  "--",
+                  integration_path,
+              ]
+          )
+          try:
+              all_c = int(all_count_s) if all_count_s else 0
+              int_c = int(int_count_s) if int_count_s else 0
+          except ValueError:
+              all_c, int_c = 0, 0
+          excluded_c = max(0, all_c - int_c)
+
+          repo = os.environ.get("GITHUB_REPOSITORY", "ghotso/HAS-pCloud-Backup")
+          if latest_tag:
+              compare_url = f"https://github.com/{repo}/compare/{latest_tag}...{new_tag}"
+          else:
+              compare_url = f"https://github.com/{repo}/commits/{new_tag}"
+
+          def fallback_notes() -> str:
+              body = (
+                  integration_log
+                  or "- *(No commits in this range touched `custom_components/pcloud_backup/` — "
+                  "e.g. workflow-only or repo metadata changes.)*"
+              )
+              return "\n".join(
+                  [
+                      f"# 🚀 Release notes – {new_tag}",
+                      "",
+                      "Automated draft (OpenAI unavailable). Only commits under "
+                      f"`{integration_path}/` are listed below.",
+                      "",
+                      "## What's changed",
+                      "",
+                      body,
+                      "",
+                      "***",
+                      "",
+                      "**Full Changelog:**",
+                      compare_url,
+                      "",
+                      "***",
+                      "",
+                      "Install: download **pcloud_backup.zip** below, extract it into your Home Assistant "
+                      "**`config/custom_components/`** directory so you have "
+                      "**`config/custom_components/pcloud_backup/`** (restart Home Assistant).",
+                      "",
+                      "> **Draft:** Publish this release on GitHub when you are ready; "
+                      "until then it stays visible only to maintainers.",
+                  ]
+              )
+
+          def openai_release_notes() -> str | None:
+              api_key = (os.environ.get("OPENAI_API_TOKEN") or "").strip()
+              if not api_key:
+                  return None
+
+              import textwrap
+              import urllib.error
+              import urllib.request
+
+              integration_block = (
+                  integration_log
+                  if integration_log
+                  else "(none — no commits in this range modified files under `custom_components/pcloud_backup/`.)"
+              )
+
+              user_prompt = textwrap.dedent(
+                  f"""\
+                  ## Release context
+                  - Integration: Home Assistant custom component **pCloud Backup** (`pcloud_backup`).
+                  - Version tag: **{new_tag}**
+                  - Previous release tag: **{latest_tag or "(first release — none)"}**
+                  - Compare URL (copy exactly for the Full Changelog line): `{compare_url}`
+                  - Commits in range (any path): **{all_c}** — commits that touched **only** paths outside
+                    `{integration_path}/` are **{excluded_c}** and must **not** appear in user-facing bullets.
+
+                  ## Commits that modified `{integration_path}/` (ONLY source for user-facing changes)
+                  {integration_block}
+
+                  ## Your task
+                  Write **GitHub-flavored Markdown** release notes for end users (not developers).
+
+                  **Rules**
+                  - Summarize **only** changes implied by the commits above. Do **not** mention CI, GitHub Actions,
+                    `.github/`, release automation, or other repo-only work — those commits are intentionally omitted.
+                  - If the list above is empty or only trivial (e.g. version bump only), say clearly that there are
+                    no functional integration changes or only maintenance/version metadata.
+                  - Omit noisy internal refactors unless they affect users.
+                  - Do **not** use a line that is exactly `---` (three hyphens) anywhere (CI constraint). Use `***`
+                    for horizontal rules if needed.
+
+                  **Required structure (order matters)**
+                  1. First line exactly: `# 🚀 Release notes – {new_tag}`
+                  2. Short intro paragraph (user-facing tone).
+                  3. Section `## What's changed` with bullet list of user-visible changes.
+                  4. Optional `## Breaking changes` — use `* None` if none.
+                  5. A line with only `***`
+                  6. Line `**Full Changelog:**` then the next line **only** the compare URL: {compare_url}
+                  7. A line with only `***`
+                  8. This install paragraph **verbatim** (single paragraph):
+                  Install: download **pcloud_backup.zip** below, extract it into your Home Assistant **`config/custom_components/`** directory so you have **`config/custom_components/pcloud_backup/`** (restart Home Assistant).
+                  9. Final blockquote line exactly:
+                  > **Draft:** Publish this release on GitHub when you are ready; until then it stays visible only to maintainers.
+
+                  Output **only** the Markdown document, no preamble or code fences.
+                  """
+              ).strip()
+
+              system_prompt = (
+                  "You write concise, accurate Markdown release notes for a Home Assistant custom integration. "
+                  "Never invent features or fixes not supported by the supplied commits."
+              )
+
+              payload = {
+                  "model": "gpt-4o-mini",
+                  "messages": [
+                      {"role": "system", "content": system_prompt},
+                      {"role": "user", "content": user_prompt},
+                  ],
+                  "temperature": 0.35,
+              }
+              req = urllib.request.Request(
+                  "https://api.openai.com/v1/chat/completions",
+                  data=json.dumps(payload).encode("utf-8"),
+                  headers={
+                      "Authorization": f"Bearer {api_key}",
+                      "Content-Type": "application/json",
+                  },
+                  method="POST",
+              )
+              try:
+                  with urllib.request.urlopen(req, timeout=120) as resp:
+                      raw = json.load(resp)
+                  content = raw["choices"][0]["message"]["content"]
+                  if isinstance(content, str) and content.strip():
+                      return content.strip()
+              except urllib.error.HTTPError as e:
+                  err_body = e.read().decode("utf-8", errors="replace")[:2000]
+                  print(f"::warning::OpenAI HTTP {e.code}: {err_body}")
+              except Exception as e:
+                  print(f"::warning::OpenAI request failed: {e!r}")
+              return None
+
+          notes = openai_release_notes() or fallback_notes()
+          nt = notes.strip()
+          if nt.startswith("```"):
+              ls = nt.splitlines()
+              if ls and ls[0].startswith("```"):
+                  ls = ls[1:]
+              if ls and ls[-1].strip().startswith("```"):
+                  ls = ls[:-1]
+              notes = "\n".join(ls).strip()
+          else:
+              notes = nt
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as gh:
+              gh.write("should_release=true\n")
+              gh.write(f"version={manifest_version}\n")
+              gh.write(f"tag={new_tag}\n")
+              gh.write(f"range_ref={range_ref}\n")
+
+          with open("release_notes.md", "w", encoding="utf-8") as rf:
+              rf.write(notes)
+
+          print(f"Will release {new_tag} (manifest {manifest_version} > {latest_tag or 'no prior tag'})")
+          PY
+
+      - name: Build pcloud_backup.zip
+        if: steps.plan.outputs.should_release == 'true'
         run: |
+          set -euo pipefail
+          rm -f pcloud_backup.zip
+          cd custom_components
+          zip -rq ../pcloud_backup.zip pcloud_backup
+          cd ..
+          unzip -l pcloud_backup.zip | head -20
+          echo "Built pcloud_backup.zip ($(wc -c < pcloud_backup.zip) bytes)"
+
+      - name: Create annotated tag, push, and draft GitHub Release with asset
+        if: steps.plan.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+          VERSION: ${{ steps.plan.outputs.version }}
+          TAG: ${{ steps.plan.outputs.tag }}
+        run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Update version and generate changelog
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          
-          # Update manifest.json version
-          python3 << EOF
-          import json
-          
-          manifest_path = "custom_components/pcloud_backup/manifest.json"
-          with open(manifest_path, 'r') as f:
-              manifest = json.load(f)
-          
-          old_version = manifest.get('version', '0.0.0')
-          manifest['version'] = "$VERSION"
-          
-          with open(manifest_path, 'w') as f:
-              json.dump(manifest, f, indent=2)
-          
-          print(f"✅ Updated version from {old_version} to $VERSION")
-          EOF
-          
-          # Generate changelog from commits since last tag
-          echo "Generating changelog from commits since last release..."
-          semantic-release changelog --unreleased || echo "No new commits or changelog generation completed"
-          
-          # Show what will be released
-          echo "📋 Changes in this release:"
-          if [ -f "CHANGELOG.md" ]; then
-            head -n 50 CHANGELOG.md | grep -A 50 "## \[Unreleased\]" || head -n 50 CHANGELOG.md
-          fi
-
-      - name: Create tag and commit
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          
-          # Check if tag already exists
-          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "⚠️ Tag v$VERSION already exists!"
+          if ! git diff --quiet; then
+            echo "::error::Working tree is dirty; cannot tag."
+            git status -sb
             exit 1
           fi
-          
-          # Add changes
-          git add custom_components/pcloud_backup/manifest.json
-          if [ -f "CHANGELOG.md" ]; then
-            git add CHANGELOG.md
-          fi
-          
-          # Commit changes (if any)
-          if ! git diff --staged --quiet; then
-            git commit -m "chore(release): v$VERSION [skip ci]"
-          fi
-          
-          # Create annotated tag
-          git tag -a "v$VERSION" -m "Release v$VERSION"
-          
-          # Push commit and tag
-          git push origin HEAD
-          git push origin "v$VERSION"
 
-      - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          VERSION: ${{ github.event.inputs.version }}
-        run: |
-          # Extract changelog content for this version
-          CHANGELOG_CONTENT=$(python3 << PYEOF
-          import re
-          import os
-          
-          version = os.environ.get('VERSION', '0.0.0')
-          try:
-              with open('CHANGELOG.md', 'r') as f:
-                  content = f.read()
-              
-              # Try to extract unreleased section or first section after [Unreleased]
-              # Look for ## [Unreleased] and get content until next ##
-              unreleased_match = re.search(r'##\s*\[Unreleased\](.*?)(?=##\s*\[|$)', content, re.DOTALL)
-              if unreleased_match:
-                  changelog_text = unreleased_match.group(1).strip()
-                  if changelog_text and changelog_text != "":
-                      print(changelog_text)
-                      exit(0)
-              
-              # Fallback: try to find version section
-              version_pattern = rf'##\s*\[?{re.escape(version)}\](?:.*?\n)?(.*?)(?=##\s*\[|$)'
-              version_match = re.search(version_pattern, content, re.DOTALL | re.IGNORECASE)
-              if version_match:
-                  print(version_match.group(1).strip())
-                  exit(0)
-              
-              # Last fallback: just print a simple release message
-              print(f"Release v{version}\n\nSee CHANGELOG.md for details.")
-          except Exception as e:
-              print(f"Release v{version}\n\nSee CHANGELOG.md for details.")
-          PYEOF
-          )
-          
-          # Create GitHub release using GitHub CLI
-          echo "$CHANGELOG_CONTENT" | gh release create "v${{ github.event.inputs.version }}" \
-            --title "v${{ github.event.inputs.version }}" \
-            --notes-file -
-          
-          echo "✅ Created GitHub release v${{ github.event.inputs.version }}"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+          gh release create "$TAG" \
+            --draft \
+            --title "$TAG" \
+            --notes-file release_notes.md \
+            pcloud_backup.zip
+
+          echo "Created draft release $TAG with pcloud_backup.zip — publish it on GitHub when ready."

--- a/README.md
+++ b/README.md
@@ -70,14 +70,15 @@ The integration uses OAuth2 authentication for secure access to your pCloud acco
 4. You'll be redirected back to the cloud Home Assistant redirect page
 5. If not already entered, enter the address to your Homeassistant installation and click on link account.
 
-#### Step 3: Configure Storage Path
+#### Step 3: Configure Storage Path & Upload Timeout
 
-1. You'll be prompted to enter the **pCloud folder path** where backups will be stored
+1. You'll be prompted for the **pCloud folder path** where backups will be stored
 2. Default path: `/HomeAssistant/Backups`
 3. You can customize this path (e.g., `/Backups/HomeAssistant` or `/MyBackups`)
-4. Click **Submit**
+4. You'll also set **Upload timeout (seconds)** — this is the maximum wall‑clock time allowed for **one** backup upload over HTTPS (large backups on slow links need a higher value). **Default: 86400 seconds (24 hours).** Allowed range: **600–172800** seconds (10 minutes–48 hours).
+5. Click **Submit**
 
-> **Note:** The storage path can only be set during initial setup. To change it later, you'll need to remove and re-add the integration.
+> **Note:** You can change **both** the backup folder path and the **upload timeout (seconds)** at any time under **Settings** → **Devices & services** → **pCloud Backup** → **Configure**. The default timeout remains **86400** seconds unless you change it. When you save, Home Assistant reloads the integration entry automatically so new values apply to the next backup.
 
 #### Step 4: Complete Setup
 
@@ -101,6 +102,8 @@ Once configured, the integration will:
 **OAuth2 Redirect URI:** The integration uses Home Assistant's OAuth2 redirect system. For Home Assistant Cloud users, the redirect URI is `https://my.home-assistant.io/redirect/oauth`. For local instances, Home Assistant automatically handles the redirect URI.
 
 **Region Detection:** The integration automatically detects whether your pCloud account uses the EU or US datacenter based on the OAuth2 callback response. No manual configuration needed!
+
+**Upload timeout:** The maximum duration (in **seconds**) for a single backup upload is configurable during setup and at any time under the integration’s **Configure** dialog. Default **86400** (24 hours); allowed **600–172800** (10 minutes–48 hours). Raise it if very large backups fail with upload timeouts on a slow uplink.
 
 ## Sensors
 

--- a/custom_components/pcloud_backup/__init__.py
+++ b/custom_components/pcloud_backup/__init__.py
@@ -56,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     auth = create_auth(
         hass=hass,
         region=region,
-        access_token=entry.data["token"]["access_token"],
+        config_entry_id=entry.entry_id,
     )
 
     # Create API instance

--- a/custom_components/pcloud_backup/api.py
+++ b/custom_components/pcloud_backup/api.py
@@ -20,11 +20,21 @@ _LOGGER = logging.getLogger(__name__)
 
 # Timeout configuration for HTTP requests
 # Connect timeout: time to establish connection
-# Total timeout: total time for entire request (important for large uploads)
+# Total timeout: entire request (large backups can exceed 1 hour on slow uplinks)
+DEFAULT_TRANSFER_TOTAL_SECONDS = 86400  # 24 hours
 CONNECT_TIMEOUT = aiohttp.ClientTimeout(connect=30)  # 30 seconds to connect
-UPLOAD_TIMEOUT = aiohttp.ClientTimeout(connect=30, total=3600)  # 1 hour total for large uploads
-DOWNLOAD_TIMEOUT = aiohttp.ClientTimeout(connect=30, total=3600)  # 1 hour total for large downloads
+UPLOAD_TIMEOUT = aiohttp.ClientTimeout(
+    connect=30, total=DEFAULT_TRANSFER_TOTAL_SECONDS
+)
+DOWNLOAD_TIMEOUT = aiohttp.ClientTimeout(
+    connect=30, total=DEFAULT_TRANSFER_TOTAL_SECONDS
+)
 STANDARD_TIMEOUT = aiohttp.ClientTimeout(connect=30, total=120)  # 2 minutes for standard requests
+
+
+def _upload_client_timeout(total_seconds: int) -> aiohttp.ClientTimeout:
+    """Client timeout for upload POST (total wall-clock including body transfer)."""
+    return aiohttp.ClientTimeout(connect=30, total=float(total_seconds))
 
 
 class PCloudAPIError(Exception):
@@ -289,7 +299,13 @@ class PCloudAPI:
             raise PCloudAPIError(f"Network error uploading {filename}: {err}") from err
 
     async def async_upload_file_from_stream(
-        self, folder_id: int, filename: str, stream: AsyncIterator[bytes], file_size: int | None = None
+        self,
+        folder_id: int,
+        filename: str,
+        stream: AsyncIterator[bytes],
+        file_size: int | None = None,
+        *,
+        upload_total_seconds: int | None = None,
     ) -> dict[str, Any]:
         """Upload a large file from async stream to pCloud using dual-path strategy.
         
@@ -306,12 +322,20 @@ class PCloudAPI:
             filename: Name of the file to upload
             stream: Async iterator yielding bytes chunks
             file_size: Known file size in bytes (None if unknown)
+            upload_total_seconds: Max seconds for the upload HTTP request (default 24h).
         
         Returns:
             pCloud API response dict
         """
         import tempfile
         import os
+
+        eff_upload_seconds = (
+            upload_total_seconds
+            if upload_total_seconds is not None
+            else DEFAULT_TRANSFER_TOTAL_SECONDS
+        )
+        upload_client_timeout = _upload_client_timeout(eff_upload_seconds)
         
         _LOGGER.info(
             "Starting streaming upload of %s (size: %s) to pCloud",
@@ -323,7 +347,11 @@ class PCloudAPI:
         if file_size and file_size > 0:
             try:
                 return await self._async_upload_via_fifo(
-                    folder_id, filename, stream, file_size
+                    folder_id,
+                    filename,
+                    stream,
+                    file_size,
+                    upload_client_timeout,
                 )
             except PCloudAPIError as fifo_err:
                 # Check if it's a connection reset (pCloud rejecting chunked encoding)
@@ -347,11 +375,16 @@ class PCloudAPI:
         
         # PATH 2: Unknown size - Use temp file in /backup
         return await self._async_upload_via_tempfile(
-            folder_id, filename, stream
+            folder_id, filename, stream, upload_client_timeout
         )
     
     async def _async_upload_via_fifo(
-        self, folder_id: int, filename: str, stream: AsyncIterator[bytes], file_size: int
+        self,
+        folder_id: int,
+        filename: str,
+        stream: AsyncIterator[bytes],
+        file_size: int,
+        upload_client_timeout: aiohttp.ClientTimeout,
     ) -> dict[str, Any]:
         """Upload via FIFO (named pipe) when file size is known.
         
@@ -379,7 +412,9 @@ class PCloudAPI:
                     "FIFO not available on this system (Windows?). "
                     "Falling back to temp file method."
                 )
-                return await self._async_upload_via_tempfile(folder_id, filename, stream)
+                return await self._async_upload_via_tempfile(
+                    folder_id, filename, stream, upload_client_timeout
+                )
             
             # Create FIFO in system temp directory (secure, uses tempfile.gettempdir())
             try:
@@ -393,7 +428,9 @@ class PCloudAPI:
                     "Falling back to temp file method.",
                     err
                 )
-                return await self._async_upload_via_tempfile(folder_id, filename, stream)
+                return await self._async_upload_via_tempfile(
+                    folder_id, filename, stream, upload_client_timeout
+                )
             
             # Create temporary name for FIFO
             fifo_fd, fifo_path = tempfile.mkstemp(suffix='.tar.fifo', dir=temp_dir)
@@ -630,7 +667,11 @@ class PCloudAPI:
             # Do NOT manually set Content-Length header - let aiohttp handle it
             try:
                 async with session.post(
-                    url, params=params, data=writer, headers=headers, timeout=UPLOAD_TIMEOUT
+                    url,
+                    params=params,
+                    data=writer,
+                    headers=headers,
+                    timeout=upload_client_timeout,
                 ) as response:
                     result = await response.json()
                     
@@ -725,7 +766,11 @@ class PCloudAPI:
                     _LOGGER.debug("Ignoring broken pipe error from writer (expected when reader closes early)")
     
     async def _async_upload_via_tempfile(
-        self, folder_id: int, filename: str, stream: AsyncIterator[bytes]
+        self,
+        folder_id: int,
+        filename: str,
+        stream: AsyncIterator[bytes],
+        upload_client_timeout: aiohttp.ClientTimeout,
     ) -> dict[str, Any]:
         """Upload via temp file in /backup when file size is unknown.
         
@@ -814,7 +859,12 @@ class PCloudAPI:
             )
             
             # Use proven async_upload_file_from_path method
-            result = await self.async_upload_file_from_path(folder_id, filename, temp_path)
+            result = await self.async_upload_file_from_path(
+                folder_id,
+                filename,
+                temp_path,
+                upload_client_timeout=upload_client_timeout,
+            )
             
             _LOGGER.info(
                 "Successfully uploaded %s via temp file (%d MB, %d chunks)",
@@ -837,7 +887,12 @@ class PCloudAPI:
                     _LOGGER.warning("Failed to delete temp file %s: %s", temp_path, cleanup_err)
 
     async def async_upload_file_from_path(
-        self, folder_id: int, filename: str, file_path: str
+        self,
+        folder_id: int,
+        filename: str,
+        file_path: str,
+        *,
+        upload_client_timeout: aiohttp.ClientTimeout | None = None,
     ) -> dict[str, Any]:
         """Upload a large file from disk to pCloud using streaming to avoid loading entire file in memory.
         
@@ -860,7 +915,9 @@ class PCloudAPI:
         except Exception as err:
             _LOGGER.error("Failed to stat file %s: %s", file_path, err)
             raise PCloudAPIError(f"File not found or inaccessible: {file_path}") from err
-        
+
+        req_timeout = upload_client_timeout or UPLOAD_TIMEOUT
+
         session = await self._get_session()
         
         # Determine if using OAuth2 (Bearer token) or digest auth (auth parameter)
@@ -905,7 +962,11 @@ class PCloudAPI:
                 _LOGGER.debug("Uploading %s to pCloud...", filename)
                 try:
                     async with session.post(
-                        url, params=params, data=form_data, headers=headers, timeout=UPLOAD_TIMEOUT
+                        url,
+                        params=params,
+                        data=form_data,
+                        headers=headers,
+                        timeout=req_timeout,
                     ) as response:
                         result = await response.json()
                         
@@ -925,8 +986,9 @@ class PCloudAPI:
                         return result
                         
                 except asyncio.TimeoutError as err:
+                    total_s = int(req_timeout.total or DEFAULT_TRANSFER_TOTAL_SECONDS)
                     _LOGGER.error(
-                        "Upload timeout for %s after %d seconds", filename, UPLOAD_TIMEOUT.total
+                        "Upload timeout for %s after %d seconds", filename, total_s
                     )
                     raise PCloudAPIError(f"Upload timeout for {filename}") from err
                 except aiohttp.ClientError as err:

--- a/custom_components/pcloud_backup/auth.py
+++ b/custom_components/pcloud_backup/auth.py
@@ -320,7 +320,8 @@ class PCloudOAuth2Auth(PCloudAuth):
         """Get OAuth2 access token."""
         if self._config_entry_id is not None:
             return self._token_from_config_entry()
-        assert self._access_token is not None
+        if self._access_token is None:
+            raise ValueError("OAuth2 static access token is missing")
         return self._access_token
 
     async def refresh_token_if_needed(self) -> None:

--- a/custom_components/pcloud_backup/auth.py
+++ b/custom_components/pcloud_backup/auth.py
@@ -276,29 +276,88 @@ class PCloudDigestAuth(PCloudAuth):
 
 
 class PCloudOAuth2Auth(PCloudAuth):
-    """OAuth2 authentication for pCloud API (for future use)."""
+    """OAuth2 authentication for pCloud API."""
 
     def __init__(
         self,
         hass: Any,
         region: str,
-        access_token: str,
+        *,
+        config_entry_id: str | None = None,
+        access_token: str | None = None,
     ) -> None:
-        """Initialize OAuth2 authentication."""
+        """Initialize OAuth2 authentication.
+
+        Prefer ``config_entry_id`` so the current access token is always read from
+        the config entry (e.g. after reauth or Home Assistant token refresh). Use
+        ``access_token`` only during the config flow before an entry exists.
+        """
+        if bool(config_entry_id) == bool(access_token):
+            raise ValueError("Specify exactly one of config_entry_id or access_token")
+
         self.hass = hass
         self.region = region.lower()
+        self._config_entry_id = config_entry_id
         self._access_token = access_token
         self._base_url = API_BASE_EU if region.lower() == "eu" else API_BASE_US
 
+    def _token_from_config_entry(self) -> str:
+        """Return the current OAuth access token from the config entry."""
+        if not self._config_entry_id:
+            raise RuntimeError("OAuth auth is not bound to a config entry")
+        entry = self.hass.config_entries.async_get_entry(self._config_entry_id)
+        if entry is None:
+            raise ValueError(f"Config entry {self._config_entry_id} not found")
+        token_container = entry.data.get("token")
+        if not isinstance(token_container, dict):
+            raise ValueError("Config entry has no OAuth token data")
+        access = token_container.get("access_token")
+        if not access:
+            raise ValueError("Config entry has no access_token")
+        return str(access)
+
     async def get_auth_token(self) -> str:
         """Get OAuth2 access token."""
+        if self._config_entry_id is not None:
+            return self._token_from_config_entry()
+        assert self._access_token is not None
         return self._access_token
 
     async def refresh_token_if_needed(self) -> None:
-        """Refresh OAuth2 token if needed."""
-        # OAuth2 token refresh logic would go here
-        # For now, tokens are persistent per pCloud documentation
-        pass
+        """Refresh OAuth2 token via Home Assistant when possible."""
+        if self._config_entry_id is None:
+            return
+
+        entry = self.hass.config_entries.async_get_entry(self._config_entry_id)
+        if entry is None:
+            return
+
+        if "auth_implementation" not in entry.data:
+            _LOGGER.debug(
+                "Skipping OAuth refresh: config entry %s has no auth_implementation",
+                self._config_entry_id,
+            )
+            return
+
+        try:
+            from homeassistant.helpers.config_entry_oauth2_flow import (
+                OAuth2Session,
+                async_get_config_entry_implementation,
+            )
+        except ImportError:
+            return
+
+        try:
+            impl = await async_get_config_entry_implementation(self.hass, entry)
+        except ValueError as err:
+            _LOGGER.warning("Could not resolve OAuth implementation: %s", err)
+            return
+
+        try:
+            session = OAuth2Session(self.hass, entry, impl)
+            await session.async_ensure_token_valid()
+        except Exception as err:
+            _LOGGER.warning("OAuth token refresh failed: %s", err)
 
     async def close(self) -> None:
         """Close OAuth2 session."""
@@ -308,19 +367,25 @@ class PCloudOAuth2Auth(PCloudAuth):
 def create_auth(
     hass: Any,
     region: str,
-    access_token: str,
+    *,
+    config_entry_id: str | None = None,
+    access_token: str | None = None,
 ) -> PCloudAuth:
     """Create OAuth2 authentication instance.
 
     Args:
         hass: Home Assistant instance
         region: pCloud region (us/eu)
-        access_token: OAuth2 access token
+        config_entry_id: If set, read access_token from this config entry on each request.
+        access_token: Static token (config flow only, before entry is created).
 
     Returns:
         PCloudAuth instance
     """
-    if not access_token:
-        raise ValueError("access_token must be provided")
-    return PCloudOAuth2Auth(hass, region, access_token)
+    return PCloudOAuth2Auth(
+        hass,
+        region,
+        config_entry_id=config_entry_id,
+        access_token=access_token,
+    )
 

--- a/custom_components/pcloud_backup/backup.py
+++ b/custom_components/pcloud_backup/backup.py
@@ -1,7 +1,6 @@
 """Backup agent implementation for pCloud."""
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import os
@@ -23,8 +22,10 @@ from homeassistant.core import HomeAssistant, callback
 from .api import PCloudAPI, PCloudAPIError
 from .const import (
     CONF_BACKUP_FOLDER,
+    CONF_UPLOAD_TIMEOUT_SECONDS,
     DATA_BACKUP_AGENT_LISTENERS,
     DEFAULT_BACKUP_FOLDER,
+    DEFAULT_UPLOAD_TIMEOUT_SECONDS,
     DOMAIN,
 )
 
@@ -336,13 +337,17 @@ class PCloudBackupAgent(BackupAgent):
             return backup_name_or_id.split(":", 1)[1]
         return backup_name_or_id
 
-    async def async_get_backup(self, backup_name: str, **kwargs: Any) -> AgentBackup | None:
-        """Get backup information by name."""
+    async def async_get_backup(self, backup_name: str, **kwargs: Any) -> AgentBackup:
+        """Get backup information by name.
+
+        Home Assistant 2025.10+ requires a concrete AgentBackup or a raised
+        BackupNotFound / BackupAgentError — returning None is deprecated.
+        """
         try:
             config_entry = self.hass.config_entries.async_get_entry(self.config_entry_id)
             if config_entry is None:
                 _LOGGER.error("Config entry not found")
-                return None
+                raise PCloudBackupError("pCloud backup agent: config entry not found")
 
             options = config_entry.options
             backup_folder = options.get(CONF_BACKUP_FOLDER, DEFAULT_BACKUP_FOLDER)
@@ -362,18 +367,20 @@ class PCloudBackupAgent(BackupAgent):
                 return backups_by_key[metadata_key]
 
             # As a final fallback, compare against derived keys from metadata
-            for key, agent_backup in backups_by_key.items():
+            for _key, agent_backup in backups_by_key.items():
                 if self._metadata_key_for_backup(agent_backup) == metadata_key:
                     return agent_backup
 
-            return None
+            raise BackupNotFound(f"Backup {backup_name} not found in pCloud")
 
+        except BackupNotFound:
+            raise
         except PCloudAPIError as err:
             _LOGGER.error("Failed to get backup: %s", err, exc_info=True)
-            return None
+            raise PCloudBackupError(f"Failed to get backup: {err}") from err
         except Exception as err:
             _LOGGER.exception("Unexpected error getting backup")
-            return None
+            raise PCloudBackupError(f"Unexpected error getting backup: {err}") from err
 
     async def async_list_backups(self, **kwargs: Any) -> list[AgentBackup]:
         """List all backups in pCloud."""
@@ -469,8 +476,15 @@ class PCloudBackupAgent(BackupAgent):
             
             # Stream directly from backup iterator to pCloud
             # Pass file_size to enable FIFO path when size is known
+            upload_timeout_s = int(
+                options.get(CONF_UPLOAD_TIMEOUT_SECONDS, DEFAULT_UPLOAD_TIMEOUT_SECONDS)
+            )
             await self.api.async_upload_file_from_stream(
-                folder_id, backup_name, stream, file_size=backup_metadata_size if backup_metadata_size > 0 else None
+                folder_id,
+                backup_name,
+                stream,
+                file_size=backup_metadata_size if backup_metadata_size > 0 else None,
+                upload_total_seconds=upload_timeout_s,
             )
 
             # Upload metadata so we can faithfully reconstruct the AgentBackup

--- a/custom_components/pcloud_backup/config_flow.py
+++ b/custom_components/pcloud_backup/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
+from homeassistant.config_entries import ConfigEntry, OptionsFlow
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -31,12 +31,31 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def _backup_options_schema(
+    *,
+    backup_folder_default: str,
+    upload_timeout_default: int,
+) -> vol.Schema:
+    """Shared schema for initial setup (folder_path) and integration options."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_BACKUP_FOLDER, default=backup_folder_default): str,
+            vol.Required(
+                CONF_UPLOAD_TIMEOUT_SECONDS,
+                default=upload_timeout_default,
+            ): vol.All(
+                vol.Coerce(int),
+                vol.Range(
+                    min=MIN_UPLOAD_TIMEOUT_SECONDS,
+                    max=MAX_UPLOAD_TIMEOUT_SECONDS,
+                ),
+            ),
+        }
+    )
+
+
 class PCloudOptionsFlowHandler(OptionsFlow):
     """Handle options flow for pCloud Backup."""
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -48,36 +67,18 @@ class PCloudOptionsFlowHandler(OptionsFlow):
         options = self.config_entry.options
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_BACKUP_FOLDER,
-                        default=options.get(CONF_BACKUP_FOLDER, DEFAULT_BACKUP_FOLDER),
-                    ): str,
-                    vol.Required(
+            data_schema=_backup_options_schema(
+                backup_folder_default=options.get(
+                    CONF_BACKUP_FOLDER, DEFAULT_BACKUP_FOLDER
+                ),
+                upload_timeout_default=int(
+                    options.get(
                         CONF_UPLOAD_TIMEOUT_SECONDS,
-                        default=int(
-                            options.get(
-                                CONF_UPLOAD_TIMEOUT_SECONDS,
-                                DEFAULT_UPLOAD_TIMEOUT_SECONDS,
-                            )
-                        ),
-                    ): vol.All(
-                        vol.Coerce(int),
-                        vol.Range(
-                            min=MIN_UPLOAD_TIMEOUT_SECONDS,
-                            max=MAX_UPLOAD_TIMEOUT_SECONDS,
-                        ),
-                    ),
-                }
+                        DEFAULT_UPLOAD_TIMEOUT_SECONDS,
+                    )
+                ),
             ),
         )
-
-
-@callback
-def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
-    """Get the options flow for this handler."""
-    return PCloudOptionsFlowHandler(config_entry)
 
 
 class PCloudOAuth2Implementation(config_entry_oauth2_flow.LocalOAuth2Implementation):
@@ -346,7 +347,12 @@ class PCloudConfigFlow(
 
     DOMAIN = DOMAIN
     VERSION = 2
-    OPTIONS_FLOW = async_get_options_flow
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(_config_entry: ConfigEntry) -> OptionsFlow:
+        """Return the options flow; core wires `config_entry` via `handler`, do not pass it into __init__."""
+        return PCloudOptionsFlowHandler()
 
     @property
     def logger(self) -> logging.Logger:
@@ -406,7 +412,12 @@ class PCloudConfigFlow(
         
         if user_input is not None:
             backup_folder = user_input.get(CONF_BACKUP_FOLDER, DEFAULT_BACKUP_FOLDER)
-            
+            upload_timeout_s = int(
+                user_input.get(
+                    CONF_UPLOAD_TIMEOUT_SECONDS, DEFAULT_UPLOAD_TIMEOUT_SECONDS
+                )
+            )
+
             # Test connection and validate folder path
             try:
                 region = getattr(self, "_oauth_region", "us")
@@ -451,6 +462,7 @@ class PCloudConfigFlow(
                         },
                         options={
                             CONF_BACKUP_FOLDER: backup_folder,
+                            CONF_UPLOAD_TIMEOUT_SECONDS: upload_timeout_s,
                         },
                     )
             except PCloudAPIError as err:
@@ -462,13 +474,9 @@ class PCloudConfigFlow(
         
         return self.async_show_form(
             step_id="folder_path",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_BACKUP_FOLDER,
-                        default=DEFAULT_BACKUP_FOLDER,
-                    ): str,
-                }
+            data_schema=_backup_options_schema(
+                backup_folder_default=DEFAULT_BACKUP_FOLDER,
+                upload_timeout_default=DEFAULT_UPLOAD_TIMEOUT_SECONDS,
             ),
             errors=errors,
         )

--- a/custom_components/pcloud_backup/config_flow.py
+++ b/custom_components/pcloud_backup/config_flow.py
@@ -16,8 +16,12 @@ from .auth import create_auth
 from .const import (
     CONF_BACKUP_FOLDER,
     CONF_REGION,
+    CONF_UPLOAD_TIMEOUT_SECONDS,
     DEFAULT_BACKUP_FOLDER,
+    DEFAULT_UPLOAD_TIMEOUT_SECONDS,
     DOMAIN,
+    MAX_UPLOAD_TIMEOUT_SECONDS,
+    MIN_UPLOAD_TIMEOUT_SECONDS,
     OAUTH2_AUTHORIZE,
     OAUTH2_CLIENT_ID,
     OAUTH2_CLIENT_SECRET,
@@ -50,6 +54,21 @@ class PCloudOptionsFlowHandler(OptionsFlow):
                         CONF_BACKUP_FOLDER,
                         default=options.get(CONF_BACKUP_FOLDER, DEFAULT_BACKUP_FOLDER),
                     ): str,
+                    vol.Required(
+                        CONF_UPLOAD_TIMEOUT_SECONDS,
+                        default=int(
+                            options.get(
+                                CONF_UPLOAD_TIMEOUT_SECONDS,
+                                DEFAULT_UPLOAD_TIMEOUT_SECONDS,
+                            )
+                        ),
+                    ): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(
+                            min=MIN_UPLOAD_TIMEOUT_SECONDS,
+                            max=MAX_UPLOAD_TIMEOUT_SECONDS,
+                        ),
+                    ),
                 }
             ),
         )

--- a/custom_components/pcloud_backup/const.py
+++ b/custom_components/pcloud_backup/const.py
@@ -32,6 +32,13 @@ CONF_REGION = "region"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_BACKUP_FOLDER = "backup_folder"
+CONF_UPLOAD_TIMEOUT_SECONDS = "upload_timeout_seconds"
+
+# Maximum time for a single upload HTTP request (large backups over slow links).
+# Default 24 hours; configurable in integration options.
+DEFAULT_UPLOAD_TIMEOUT_SECONDS = 86400
+MIN_UPLOAD_TIMEOUT_SECONDS = 600
+MAX_UPLOAD_TIMEOUT_SECONDS = 172800
 
 # Sensor attributes
 ATTR_REMOTE_BACKUP_COUNT = "remote_backup_count"

--- a/custom_components/pcloud_backup/manifest.json
+++ b/custom_components/pcloud_backup/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "aiohttp>=3.8.0"
   ],
-  "version": "2.2.0"
+  "version": "2.3.0"
 }

--- a/custom_components/pcloud_backup/strings.json
+++ b/custom_components/pcloud_backup/strings.json
@@ -13,9 +13,10 @@
       },
       "folder_path": {
         "title": "Configure Backup Folder",
-        "description": "Enter the folder path in pCloud where backups will be stored. The folder will be created if it doesn't exist.",
+        "description": "Enter the folder path in pCloud where backups will be stored. The folder will be created if it doesn't exist. Set upload timeout for large backups over slow uplinks.",
         "data": {
-          "backup_folder": "Backup Folder Path"
+          "backup_folder": "Backup Folder Path",
+          "upload_timeout_seconds": "Upload timeout (seconds)"
         }
       }
     },

--- a/custom_components/pcloud_backup/strings.json
+++ b/custom_components/pcloud_backup/strings.json
@@ -33,9 +33,10 @@
     "step": {
       "init": {
         "title": "pCloud Backup Options",
-        "description": "Configure the backup folder path in pCloud.",
+        "description": "Configure the backup folder path in pCloud and upload timeout for large backups.",
         "data": {
-          "backup_folder": "Backup Folder Path"
+          "backup_folder": "Backup Folder Path",
+          "upload_timeout_seconds": "Upload timeout (seconds)"
         }
       }
     }

--- a/custom_components/pcloud_backup/translations/de.json
+++ b/custom_components/pcloud_backup/translations/de.json
@@ -33,9 +33,10 @@
     "step": {
       "init": {
         "title": "pCloud Backup Optionen",
-        "description": "Konfiguriere den Backup-Pfad in pCloud.",
+        "description": "Konfiguriere den Backup-Pfad in pCloud und das Upload-Timeout f\u00fcr gro\u00dfe Backups.",
         "data": {
-          "backup_folder": "Backup-Pfad"
+          "backup_folder": "Backup-Pfad",
+          "upload_timeout_seconds": "Upload-Timeout (Sekunden)"
         }
       }
     }

--- a/custom_components/pcloud_backup/translations/de.json
+++ b/custom_components/pcloud_backup/translations/de.json
@@ -13,9 +13,10 @@
       },
       "folder_path": {
         "title": "Backup-Ordner konfigurieren",
-        "description": "Gib den Ordnerpfad in pCloud ein, in dem Backups gespeichert werden sollen. Der Ordner wird erstellt, falls er nicht existiert.",
+        "description": "Gib den Ordnerpfad in pCloud ein, in dem Backups gespeichert werden sollen. Der Ordner wird erstellt, falls er nicht existiert. Lege das Upload-Timeout f\u00fcr gro\u00dfe Backups bei langsamen Uploads fest.",
         "data": {
-          "backup_folder": "Backup-Pfad"
+          "backup_folder": "Backup-Pfad",
+          "upload_timeout_seconds": "Upload-Timeout (Sekunden)"
         }
       }
     },

--- a/custom_components/pcloud_backup/translations/en.json
+++ b/custom_components/pcloud_backup/translations/en.json
@@ -13,9 +13,10 @@
       },
       "folder_path": {
         "title": "Configure Backup Folder",
-        "description": "Enter the folder path in pCloud where backups will be stored. The folder will be created if it doesn't exist.",
+        "description": "Enter the folder path in pCloud where backups will be stored. The folder will be created if it doesn't exist. Set upload timeout for large backups over slow uplinks.",
         "data": {
-          "backup_folder": "Backup Folder Path"
+          "backup_folder": "Backup Folder Path",
+          "upload_timeout_seconds": "Upload timeout (seconds)"
         }
       }
     },

--- a/custom_components/pcloud_backup/translations/en.json
+++ b/custom_components/pcloud_backup/translations/en.json
@@ -33,9 +33,10 @@
     "step": {
       "init": {
         "title": "pCloud Backup Options",
-        "description": "Configure the backup folder path in pCloud.",
+        "description": "Configure the backup folder path in pCloud and upload timeout for large backups.",
         "data": {
-          "backup_folder": "Backup Folder Path"
+          "backup_folder": "Backup Folder Path",
+          "upload_timeout_seconds": "Upload timeout (seconds)"
         }
       }
     }


### PR DESCRIPTION
## Summary

This branch brings **v2.3.0** onto `main`: more reliable backups and OAuth behaviour, configurable upload timeouts, Home Assistant–compatible backup agent semantics, a fixed **Configure** / options UI, and an automated **draft** release pipeline with integration-only release notes.

Fixes **#23**, **#24**, and **#25** (see below).

---

## User-facing

- **Large backups / timeouts (#23):** Default HTTP upload (and download) window is **24 hours**; **upload timeout (seconds)** is configurable (**600–172800**, default **86400**) during setup and under **Configure**.
- **Backup agent / HA warnings (#24):** `async_get_backup` now returns an `AgentBackup` or raises **`BackupNotFound`** / **`PCloudBackupError`** instead of **`None`**, matching Home Assistant’s BackupAgent expectations (2025.10+).
- **OAuth / “unavailable” after reload (#25):** Access token is read from the **config entry** on use; OAuth refresh goes through Home Assistant’s **`OAuth2Session`** where applicable so tokens are not stuck stale after reload or reauth.

---

## Integration & docs

- **Options flow:** `async_get_options_flow()` is implemented on **`PCloudConfigFlow`** (the old `OPTIONS_FLOW` attribute is not used by core). **`OptionsFlow`** no longer assigns **`config_entry`** in `__init__` (read-only property on current HA).
- **Setup + options:** Shared schema for **backup folder path** and **upload timeout** on the OAuth **folder_path** step and in **Configure**; README and **en** / **de** / **strings.json** updated (path and timeout can be changed anytime).

---

## Automation

- **`.github/workflows/release.yml`:** On push to **`main`**, if **`manifest.json`** version is **greater** than the latest **`v*`** tag and that tag does not exist yet: create tag, **draft** GitHub release, **`pcloud_backup.zip`** (root = `pcloud_backup/` for `custom_components`), and release notes from commits under **`custom_components/pcloud_backup/`** (optional **OpenAI** draft via **`OPENAI_API_TOKEN`**).

---

## Type of change

- [x] Bug fix (options flow, backup agent `None`, OAuth staleness, upload timeouts)
- [x] New feature (configurable timeout, automated draft releases)
- [x] Documentation (README, translations)
- [ ] Breaking change

---

## Related issues

| Issue | Topic |
|-------|--------|
| [#23](https://github.com/ghotso/HAS-pCloud-Backup/issues/23) | Intermittent upload timeout on very large backups |
| [#24](https://github.com/ghotso/HAS-pCloud-Backup/issues/24) | `BackupAgent.async_get_backup` returning `None` |
| [#25](https://github.com/ghotso/HAS-pCloud-Backup/issues/25) | Backup / location issues after HA upgrade, OAuth reload |

Closes #23, closes #24, closes #25.

---

## Commits on this PR

1. `feat(auth):` OAuth2 token from config entry, upload timeout plumbing, backup agent exceptions  
2. `feat(release):` Automated tag + draft release + zip + integration-scoped notes (OpenAI optional)  
3. `fix(config_flow):` Options flow registration, shared path/timeout schema, README + i18n  
4. `chore(manifest):` bump version to **2.3.0**
