### PR TITLE
fix(release): HACS zip must use flat archive paths (match v2.2.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,9 +200,10 @@ jobs:
                       "",
                       "***",
                       "",
-                      "Install: download **pcloud_backup.zip** below, extract it into your Home Assistant "
-                      "**`config/custom_components/`** directory so you have "
-                      "**`config/custom_components/pcloud_backup/`** (restart Home Assistant).",
+                      "Install: **HACS** — download/update as usual. **Manual** — create "
+                      "**`config/custom_components/pcloud_backup/`**, download **pcloud_backup.zip**, extract "
+                      "**all files** from the zip into that folder (you should see **`manifest.json`** next to "
+                      "**`__init__.py`**), then restart Home Assistant.",
                       "",
                       "> **Draft:** Publish this release on GitHub when you are ready; "
                       "until then it stays visible only to maintainers.",
@@ -258,7 +259,7 @@ jobs:
                   6. Line `**Full Changelog:**` then the next line **only** the compare URL: {compare_url}
                   7. A line with only `***`
                   8. This install paragraph **verbatim** (single paragraph):
-                  Install: download **pcloud_backup.zip** below, extract it into your Home Assistant **`config/custom_components/`** directory so you have **`config/custom_components/pcloud_backup/`** (restart Home Assistant).
+                  Install: **HACS** — download/update as usual. **Manual** — create **`config/custom_components/pcloud_backup/`**, download **pcloud_backup.zip**, extract **all files** from the zip into that folder (you should see **`manifest.json`** next to **`__init__.py`**), then restart Home Assistant.
                   9. Final blockquote line exactly:
                   > **Draft:** Publish this release on GitHub when you are ready; until then it stays visible only to maintainers.
 
@@ -330,9 +331,11 @@ jobs:
         run: |
           set -euo pipefail
           rm -f pcloud_backup.zip
-          cd custom_components
-          zip -rq ../pcloud_backup.zip pcloud_backup
-          cd ..
+          # HACS zip_release: extractall() targets config/custom_components/<domain>/ with no path rewrite.
+          # Archive paths must be integration-root (manifest.json at zip root), not pcloud_backup/...
+          cd custom_components/pcloud_backup
+          zip -rq ../../pcloud_backup.zip .
+          cd ../..
           unzip -l pcloud_backup.zip | head -20
           echo "Built pcloud_backup.zip ($(wc -c < pcloud_backup.zip) bytes)"
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ A native Home Assistant Backup Agent integration for pCloud, enabling users to s
 
 ### Manual Installation
 
-1. Download the [latest release][releases]
-2. Extract the `pcloud_backup` folder to your `custom_components` directory:
+1. Download **pcloud_backup.zip** from the [latest release][releases]
+2. On your Home Assistant host, create **`config/custom_components/pcloud_backup/`** if it does not exist, then extract **all contents** of the zip into that folder (not into `custom_components/` directly — **`manifest.json`** must end up at **`config/custom_components/pcloud_backup/manifest.json`**).
    ```
-   config/custom_components/pcloud_backup/
+   config/custom_components/pcloud_backup/manifest.json
    ```
 3. **Restart Home Assistant** (required after installation)
 4. After restart, go to **Settings** → **Devices & Services**


### PR DESCRIPTION
## Summary

HACS integrations with `"zip_release": true` download `pcloud_backup.zip` and run `ZipFile.extractall()` directly into `config/custom_components/<domain>/` with **no** path rewriting. Archives must therefore contain integration files at the **root** of the zip (`manifest.json`, `__init__.py`, …), not under a `pcloud_backup/` prefix.

The release workflow had regressed to `zip -r … pcloud_backup` from `custom_components/`, which produced `pcloud_backup/manifest.json` inside the archive and would install to `…/custom_components/pcloud_backup/pcloud_backup/` — wrong for HACS.

## Changes

- **`.github/workflows/release.yml`** — Build the zip from `custom_components/pcloud_backup/` with `zip -rq ../../pcloud_backup.zip .` so paths match **v2.2.0** and HACS expectations. Release note template + OpenAI verbatim install paragraph updated for **manual** installs (extract into `config/custom_components/pcloud_backup/`); **HACS** users unchanged in practice.
- **`README.md`** — Manual installation steps aligned with the flat zip layout.

## Verification

- Confirmed **v2.2.0** `pcloud_backup.zip` on GitHub uses a flat root (e.g. `manifest.json` at archive root, no `pcloud_backup/` segment).
- Matches HACS behaviour in [`hacs/integration` `async_download_zip_file`](https://github.com/hacs/integration/blob/main/custom_components/hacs/repositories/base.py#L598-L601).

## Note for maintainers

Any **draft or published release** that was built with the old zip step still has a bad asset on GitHub until the workflow is re-run or the zip is replaced manually.
