### PR TITLE
feat: add optional permanent delete (Trash) support

### DIFF
--- a/PRD/PRD.md
+++ b/PRD/PRD.md
@@ -100,6 +100,10 @@ custom_components/pcloud_backup/
 
 * Endpoint: `POST /deletefile`
 * Throws `BackupNotFound` (as per HA API) if missing.
+* Optional `permanent_delete` setting: when enabled, also calls `POST /trash_clear`
+  on the same file id(s) after `deletefile`, permanently purging the backup
+  from pCloud Trash and freeing quota immediately. Default `false` (deleted
+  backups remain recoverable in Trash, matching prior behavior).
 
 ---
 

--- a/custom_components/pcloud_backup/api.py
+++ b/custom_components/pcloud_backup/api.py
@@ -1047,6 +1047,13 @@ class PCloudAPI:
         """Delete a file from pCloud."""
         await self._request("POST", "/deletefile", {"fileid": file_id})
 
+    async def async_trash_clear(self, file_id: int) -> None:
+        """Permanently remove a file from Trash, freeing quota immediately.
+
+        Intended to be called after async_delete_file with the same file_id.
+        """
+        await self._request("POST", "/trash_clear", {"fileid": file_id})
+
     async def async_download_file(self, file_id: int) -> bytes:
         """Download a small file from pCloud (returns bytes).
         

--- a/custom_components/pcloud_backup/backup.py
+++ b/custom_components/pcloud_backup/backup.py
@@ -22,9 +22,11 @@ from homeassistant.core import HomeAssistant, callback
 from .api import PCloudAPI, PCloudAPIError
 from .const import (
     CONF_BACKUP_FOLDER,
+    CONF_PERMANENT_DELETE,
     CONF_UPLOAD_TIMEOUT_SECONDS,
     DATA_BACKUP_AGENT_LISTENERS,
     DEFAULT_BACKUP_FOLDER,
+    DEFAULT_PERMANENT_DELETE,
     DEFAULT_UPLOAD_TIMEOUT_SECONDS,
     DOMAIN,
 )
@@ -668,13 +670,23 @@ class PCloudBackupAgent(BackupAgent):
             if file_id is None:
                 raise BackupNotFound(f"Backup {backup_name} has no file ID")
 
+            permanent_delete = options.get(
+                CONF_PERMANENT_DELETE, DEFAULT_PERMANENT_DELETE
+            )
+
             _LOGGER.info("Deleting backup %s from pCloud", backup_name)
             await self.api.async_delete_file(file_id)
+            if permanent_delete:
+                await self._async_trash_clear(file_id, backup_name)
             # Also remove metadata file if present
             metadata_item = metadata_files.get(metadata_key)
             if metadata_item and metadata_item.get("fileid"):
                 try:
                     await self.api.async_delete_file(metadata_item["fileid"])
+                    if permanent_delete:
+                        await self._async_trash_clear(
+                            metadata_item["fileid"], backup_name
+                        )
                 except Exception as err:  # noqa: BLE001
                     _LOGGER.warning(
                         "Failed to delete metadata for backup %s: %s", backup_name, err
@@ -692,6 +704,18 @@ class PCloudBackupAgent(BackupAgent):
             _LOGGER.exception("Unexpected error deleting backup")
             raise PCloudBackupError(f"Unexpected error deleting backup: {err}") from err
 
+    async def _async_trash_clear(self, file_id: int, backup_name: str) -> None:
+        """Permanently purge a deleted file from Trash.
 
+        Best-effort: failures are logged but don't fail the overall delete,
+        since deletefile already succeeded and the backup is no longer
+        listed - it would just remain in Trash until manually emptied.
+        """
+        try:
+            await self.api.async_trash_clear(file_id)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning(
+                "Failed to purge backup %s from Trash: %s", backup_name, err
+            )
 
 

--- a/custom_components/pcloud_backup/backup.py
+++ b/custom_components/pcloud_backup/backup.py
@@ -676,23 +676,34 @@ class PCloudBackupAgent(BackupAgent):
 
             _LOGGER.info("Deleting backup %s from pCloud", backup_name)
             await self.api.async_delete_file(file_id)
+            purge_failed = False
             if permanent_delete:
-                await self._async_trash_clear(file_id, backup_name)
-            # Also remove metadata file if present
+                purge_failed |= not await self._async_trash_clear(
+                    file_id, backup_name, "backup"
+                )
+            # Also remove metadata file if present. _async_trash_clear never
+            # raises, so this try/except only guards async_delete_file.
             metadata_item = metadata_files.get(metadata_key)
             if metadata_item and metadata_item.get("fileid"):
                 try:
                     await self.api.async_delete_file(metadata_item["fileid"])
                     if permanent_delete:
-                        await self._async_trash_clear(
-                            metadata_item["fileid"], backup_name
+                        purge_failed |= not await self._async_trash_clear(
+                            metadata_item["fileid"], backup_name, "metadata"
                         )
                 except Exception as err:  # noqa: BLE001
                     _LOGGER.warning(
                         "Failed to delete metadata for backup %s: %s", backup_name, err
                     )
 
-            _LOGGER.info("Successfully deleted backup %s", backup_name)
+            if permanent_delete and purge_failed:
+                _LOGGER.warning(
+                    "Deleted backup %s, but it may still be recoverable in "
+                    "pCloud Trash because permanently purging it failed",
+                    backup_name,
+                )
+            else:
+                _LOGGER.info("Successfully deleted backup %s", backup_name)
 
         except BackupNotFound:
             # Re-raise BackupNotFound as-is (it's already a BackupAgentError subclass)
@@ -704,18 +715,34 @@ class PCloudBackupAgent(BackupAgent):
             _LOGGER.exception("Unexpected error deleting backup")
             raise PCloudBackupError(f"Unexpected error deleting backup: {err}") from err
 
-    async def _async_trash_clear(self, file_id: int, backup_name: str) -> None:
+    async def _async_trash_clear(
+        self, file_id: int, backup_name: str, file_kind: str
+    ) -> bool:
         """Permanently purge a deleted file from Trash.
 
         Best-effort: failures are logged but don't fail the overall delete,
         since deletefile already succeeded and the backup is no longer
         listed - it would just remain in Trash until manually emptied.
+        Returns True if the file was purged, False otherwise.
         """
+        if not isinstance(file_id, int) or file_id <= 0:
+            _LOGGER.warning(
+                "Skipping Trash purge of %s for backup %s: invalid file ID %r",
+                file_kind,
+                backup_name,
+                file_id,
+            )
+            return False
         try:
             await self.api.async_trash_clear(file_id)
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning(
-                "Failed to purge backup %s from Trash: %s", backup_name, err
+                "Failed to purge %s for backup %s from Trash: %s",
+                file_kind,
+                backup_name,
+                err,
             )
+            return False
+        return True
 
 

--- a/custom_components/pcloud_backup/backup.py
+++ b/custom_components/pcloud_backup/backup.py
@@ -698,8 +698,9 @@ class PCloudBackupAgent(BackupAgent):
 
             if permanent_delete and purge_failed:
                 _LOGGER.warning(
-                    "Deleted backup %s, but it may still be recoverable in "
-                    "pCloud Trash because permanently purging it failed",
+                    "Deleted backup %s, but permanently purging one or more "
+                    "related files from pCloud Trash failed — they may still "
+                    "be recoverable until Trash is emptied",
                     backup_name,
                 )
             else:

--- a/custom_components/pcloud_backup/config_flow.py
+++ b/custom_components/pcloud_backup/config_flow.py
@@ -15,9 +15,11 @@ from .api import PCloudAPI, PCloudAPIError
 from .auth import create_auth
 from .const import (
     CONF_BACKUP_FOLDER,
+    CONF_PERMANENT_DELETE,
     CONF_REGION,
     CONF_UPLOAD_TIMEOUT_SECONDS,
     DEFAULT_BACKUP_FOLDER,
+    DEFAULT_PERMANENT_DELETE,
     DEFAULT_UPLOAD_TIMEOUT_SECONDS,
     DOMAIN,
     MAX_UPLOAD_TIMEOUT_SECONDS,
@@ -35,6 +37,7 @@ def _backup_options_schema(
     *,
     backup_folder_default: str,
     upload_timeout_default: int,
+    permanent_delete_default: bool,
 ) -> vol.Schema:
     """Shared schema for initial setup (folder_path) and integration options."""
     return vol.Schema(
@@ -50,6 +53,9 @@ def _backup_options_schema(
                     max=MAX_UPLOAD_TIMEOUT_SECONDS,
                 ),
             ),
+            vol.Required(
+                CONF_PERMANENT_DELETE, default=permanent_delete_default
+            ): bool,
         }
     )
 
@@ -76,6 +82,9 @@ class PCloudOptionsFlowHandler(OptionsFlow):
                         CONF_UPLOAD_TIMEOUT_SECONDS,
                         DEFAULT_UPLOAD_TIMEOUT_SECONDS,
                     )
+                ),
+                permanent_delete_default=options.get(
+                    CONF_PERMANENT_DELETE, DEFAULT_PERMANENT_DELETE
                 ),
             ),
         )
@@ -417,6 +426,9 @@ class PCloudConfigFlow(
                     CONF_UPLOAD_TIMEOUT_SECONDS, DEFAULT_UPLOAD_TIMEOUT_SECONDS
                 )
             )
+            permanent_delete = user_input.get(
+                CONF_PERMANENT_DELETE, DEFAULT_PERMANENT_DELETE
+            )
 
             # Test connection and validate folder path
             try:
@@ -463,6 +475,7 @@ class PCloudConfigFlow(
                         options={
                             CONF_BACKUP_FOLDER: backup_folder,
                             CONF_UPLOAD_TIMEOUT_SECONDS: upload_timeout_s,
+                            CONF_PERMANENT_DELETE: permanent_delete,
                         },
                     )
             except PCloudAPIError as err:
@@ -477,6 +490,7 @@ class PCloudConfigFlow(
             data_schema=_backup_options_schema(
                 backup_folder_default=DEFAULT_BACKUP_FOLDER,
                 upload_timeout_default=DEFAULT_UPLOAD_TIMEOUT_SECONDS,
+                permanent_delete_default=DEFAULT_PERMANENT_DELETE,
             ),
             errors=errors,
         )

--- a/custom_components/pcloud_backup/const.py
+++ b/custom_components/pcloud_backup/const.py
@@ -33,6 +33,12 @@ CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 CONF_BACKUP_FOLDER = "backup_folder"
 CONF_UPLOAD_TIMEOUT_SECONDS = "upload_timeout_seconds"
+CONF_PERMANENT_DELETE = "permanent_delete"
+
+# When True, deleted backups are also purged from Trash (trash_clear),
+# freeing quota immediately. When False (default), deletefile only -
+# deleted backups remain recoverable via pCloud Trash.
+DEFAULT_PERMANENT_DELETE = False
 
 # Maximum time for a single upload HTTP request (large backups over slow links).
 # Default 24 hours; configurable in integration options.

--- a/custom_components/pcloud_backup/strings.json
+++ b/custom_components/pcloud_backup/strings.json
@@ -16,7 +16,11 @@
         "description": "Enter the folder path in pCloud where backups will be stored. The folder will be created if it doesn't exist. Set upload timeout for large backups over slow uplinks.",
         "data": {
           "backup_folder": "Backup Folder Path",
-          "upload_timeout_seconds": "Upload timeout (seconds)"
+          "upload_timeout_seconds": "Upload timeout (seconds)",
+          "permanent_delete": "Permanently delete backups (skip Trash)"
+        },
+        "data_description": {
+          "permanent_delete": "When enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately. When disabled (default), deleted backups remain recoverable in Trash."
         }
       }
     },
@@ -37,7 +41,11 @@
         "description": "Configure the backup folder path in pCloud and upload timeout for large backups.",
         "data": {
           "backup_folder": "Backup Folder Path",
-          "upload_timeout_seconds": "Upload timeout (seconds)"
+          "upload_timeout_seconds": "Upload timeout (seconds)",
+          "permanent_delete": "Permanently delete backups (skip Trash)"
+        },
+        "data_description": {
+          "permanent_delete": "When enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately. When disabled (default), deleted backups remain recoverable in Trash."
         }
       }
     }

--- a/custom_components/pcloud_backup/strings.json
+++ b/custom_components/pcloud_backup/strings.json
@@ -20,7 +20,7 @@
           "permanent_delete": "Permanently delete backups (skip Trash)"
         },
         "data_description": {
-          "permanent_delete": "When enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately. When disabled (default), deleted backups remain recoverable in Trash."
+          "permanent_delete": "Warning: when enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately - it cannot be recovered afterwards. When disabled (default), deleted backups remain recoverable in Trash."
         }
       }
     },
@@ -45,7 +45,7 @@
           "permanent_delete": "Permanently delete backups (skip Trash)"
         },
         "data_description": {
-          "permanent_delete": "When enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately. When disabled (default), deleted backups remain recoverable in Trash."
+          "permanent_delete": "Warning: when enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately - it cannot be recovered afterwards. When disabled (default), deleted backups remain recoverable in Trash."
         }
       }
     }

--- a/custom_components/pcloud_backup/translations/de.json
+++ b/custom_components/pcloud_backup/translations/de.json
@@ -17,10 +17,10 @@
         "data": {
           "backup_folder": "Backup-Pfad",
           "upload_timeout_seconds": "Upload-Timeout (Sekunden)",
-          "permanent_delete": "Backups endgültig löschen (Papierkorb überspringen)"
+          "permanent_delete": "Backups dauerhaft löschen"
         },
         "data_description": {
-          "permanent_delete": "Warnung: Wenn aktiviert, wird ein gelöschtes Backup zusätzlich aus dem pCloud-Papierkorb entfernt und das Kontingent sofort freigegeben - es kann danach nicht mehr wiederhergestellt werden. Wenn deaktiviert (Standard), bleibt ein gelöschtes Backup im Papierkorb wiederherstellbar."
+          "permanent_delete": "Warnung: Wenn aktiviert, wird ein gelöschtes Backup zusätzlich aus dem pCloud-Papierkorb entfernt und der Speicherplatz sofort freigegeben - es kann danach nicht mehr wiederhergestellt werden. Wenn deaktiviert (Standard), bleibt ein gelöschtes Backup im Papierkorb wiederherstellbar."
         }
       }
     },
@@ -42,10 +42,10 @@
         "data": {
           "backup_folder": "Backup-Pfad",
           "upload_timeout_seconds": "Upload-Timeout (Sekunden)",
-          "permanent_delete": "Backups endgültig löschen (Papierkorb überspringen)"
+          "permanent_delete": "Backups dauerhaft löschen"
         },
         "data_description": {
-          "permanent_delete": "Warnung: Wenn aktiviert, wird ein gelöschtes Backup zusätzlich aus dem pCloud-Papierkorb entfernt und das Kontingent sofort freigegeben - es kann danach nicht mehr wiederhergestellt werden. Wenn deaktiviert (Standard), bleibt ein gelöschtes Backup im Papierkorb wiederherstellbar."
+          "permanent_delete": "Warnung: Wenn aktiviert, wird ein gelöschtes Backup zusätzlich aus dem pCloud-Papierkorb entfernt und der Speicherplatz sofort freigegeben - es kann danach nicht mehr wiederhergestellt werden. Wenn deaktiviert (Standard), bleibt ein gelöschtes Backup im Papierkorb wiederherstellbar."
         }
       }
     }

--- a/custom_components/pcloud_backup/translations/de.json
+++ b/custom_components/pcloud_backup/translations/de.json
@@ -16,7 +16,11 @@
         "description": "Gib den Ordnerpfad in pCloud ein, in dem Backups gespeichert werden sollen. Der Ordner wird erstellt, falls er nicht existiert. Lege das Upload-Timeout f\u00fcr gro\u00dfe Backups bei langsamen Uploads fest.",
         "data": {
           "backup_folder": "Backup-Pfad",
-          "upload_timeout_seconds": "Upload-Timeout (Sekunden)"
+          "upload_timeout_seconds": "Upload-Timeout (Sekunden)",
+          "permanent_delete": "Backups endgültig löschen (Papierkorb überspringen)"
+        },
+        "data_description": {
+          "permanent_delete": "Wenn aktiviert, wird ein gelöschtes Backup zusätzlich aus dem pCloud-Papierkorb entfernt und das Kontingent sofort freigegeben. Wenn deaktiviert (Standard), bleibt ein gelöschtes Backup im Papierkorb wiederherstellbar."
         }
       }
     },
@@ -37,7 +41,11 @@
         "description": "Konfiguriere den Backup-Pfad in pCloud und das Upload-Timeout f\u00fcr gro\u00dfe Backups.",
         "data": {
           "backup_folder": "Backup-Pfad",
-          "upload_timeout_seconds": "Upload-Timeout (Sekunden)"
+          "upload_timeout_seconds": "Upload-Timeout (Sekunden)",
+          "permanent_delete": "Backups endgültig löschen (Papierkorb überspringen)"
+        },
+        "data_description": {
+          "permanent_delete": "Wenn aktiviert, wird ein gelöschtes Backup zusätzlich aus dem pCloud-Papierkorb entfernt und das Kontingent sofort freigegeben. Wenn deaktiviert (Standard), bleibt ein gelöschtes Backup im Papierkorb wiederherstellbar."
         }
       }
     }

--- a/custom_components/pcloud_backup/translations/de.json
+++ b/custom_components/pcloud_backup/translations/de.json
@@ -20,7 +20,7 @@
           "permanent_delete": "Backups endgültig löschen (Papierkorb überspringen)"
         },
         "data_description": {
-          "permanent_delete": "Wenn aktiviert, wird ein gelöschtes Backup zusätzlich aus dem pCloud-Papierkorb entfernt und das Kontingent sofort freigegeben. Wenn deaktiviert (Standard), bleibt ein gelöschtes Backup im Papierkorb wiederherstellbar."
+          "permanent_delete": "Warnung: Wenn aktiviert, wird ein gelöschtes Backup zusätzlich aus dem pCloud-Papierkorb entfernt und das Kontingent sofort freigegeben - es kann danach nicht mehr wiederhergestellt werden. Wenn deaktiviert (Standard), bleibt ein gelöschtes Backup im Papierkorb wiederherstellbar."
         }
       }
     },
@@ -45,7 +45,7 @@
           "permanent_delete": "Backups endgültig löschen (Papierkorb überspringen)"
         },
         "data_description": {
-          "permanent_delete": "Wenn aktiviert, wird ein gelöschtes Backup zusätzlich aus dem pCloud-Papierkorb entfernt und das Kontingent sofort freigegeben. Wenn deaktiviert (Standard), bleibt ein gelöschtes Backup im Papierkorb wiederherstellbar."
+          "permanent_delete": "Warnung: Wenn aktiviert, wird ein gelöschtes Backup zusätzlich aus dem pCloud-Papierkorb entfernt und das Kontingent sofort freigegeben - es kann danach nicht mehr wiederhergestellt werden. Wenn deaktiviert (Standard), bleibt ein gelöschtes Backup im Papierkorb wiederherstellbar."
         }
       }
     }

--- a/custom_components/pcloud_backup/translations/en.json
+++ b/custom_components/pcloud_backup/translations/en.json
@@ -16,7 +16,11 @@
         "description": "Enter the folder path in pCloud where backups will be stored. The folder will be created if it doesn't exist. Set upload timeout for large backups over slow uplinks.",
         "data": {
           "backup_folder": "Backup Folder Path",
-          "upload_timeout_seconds": "Upload timeout (seconds)"
+          "upload_timeout_seconds": "Upload timeout (seconds)",
+          "permanent_delete": "Permanently delete backups (skip Trash)"
+        },
+        "data_description": {
+          "permanent_delete": "When enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately. When disabled (default), deleted backups remain recoverable in Trash."
         }
       }
     },
@@ -37,7 +41,11 @@
         "description": "Configure the backup folder path in pCloud and upload timeout for large backups.",
         "data": {
           "backup_folder": "Backup Folder Path",
-          "upload_timeout_seconds": "Upload timeout (seconds)"
+          "upload_timeout_seconds": "Upload timeout (seconds)",
+          "permanent_delete": "Permanently delete backups (skip Trash)"
+        },
+        "data_description": {
+          "permanent_delete": "When enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately. When disabled (default), deleted backups remain recoverable in Trash."
         }
       }
     }

--- a/custom_components/pcloud_backup/translations/en.json
+++ b/custom_components/pcloud_backup/translations/en.json
@@ -20,7 +20,7 @@
           "permanent_delete": "Permanently delete backups (skip Trash)"
         },
         "data_description": {
-          "permanent_delete": "When enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately. When disabled (default), deleted backups remain recoverable in Trash."
+          "permanent_delete": "Warning: when enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately - it cannot be recovered afterwards. When disabled (default), deleted backups remain recoverable in Trash."
         }
       }
     },
@@ -45,7 +45,7 @@
           "permanent_delete": "Permanently delete backups (skip Trash)"
         },
         "data_description": {
-          "permanent_delete": "When enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately. When disabled (default), deleted backups remain recoverable in Trash."
+          "permanent_delete": "Warning: when enabled, deleting a backup also purges it from pCloud Trash, freeing quota immediately - it cannot be recovered afterwards. When disabled (default), deleted backups remain recoverable in Trash."
         }
       }
     }


### PR DESCRIPTION
Implements the scope proposed in #29.

## Summary
- New `permanent_delete` option (default `false`, current behavior unchanged).
- When enabled, `async_delete_backup` calls `trash_clear` on the deleted backup and metadata file ids after `deletefile`, permanently purging them from pCloud Trash and freeing quota immediately.
- `trash_clear` failures are tracked per file (backup/metadata); if either fails, the delete still succeeds (matching the existing metadata-delete error handling style) but logs a warning that the backup may still be recoverable in Trash, rather than silently logging "Successfully deleted".
- `_async_trash_clear` validates the file id before calling `trash_clear`.
- Exposed as a checkbox in both the initial setup (folder/options step) and the integration's Options flow, with English and German strings, and an explicit warning that enabling it makes deletions unrecoverable.
- `PRD/PRD.md` updated to document the optional `trash_clear` step.

## Files changed
- `custom_components/pcloud_backup/const.py` — `CONF_PERMANENT_DELETE` / `DEFAULT_PERMANENT_DELETE`
- `custom_components/pcloud_backup/api.py` — `async_trash_clear(file_id)`
- `custom_components/pcloud_backup/backup.py` — `async_delete_backup` + `_async_trash_clear` helper
- `custom_components/pcloud_backup/config_flow.py` — shared options schema + both flow steps
- `custom_components/pcloud_backup/strings.json` + `translations/{en,de}.json`
- `PRD/PRD.md`

## Test plan
- [ ] Manual: with `permanent_delete=false` (default), delete a backup — confirm it lands in pCloud Trash as before.
- [ ] Manual: with `permanent_delete=true`, delete a backup — confirm `deletefile` succeeds and the same file id is then purged from Trash (`trash_clear`), freeing quota immediately.
- [ ] Manual: toggle the option via Settings → Devices & services → pCloud Backup → Configure, confirm it persists and reload applies it.
- No automated test suite exists in this repo yet; happy to follow up with `pytest-homeassistant-custom-component` coverage for this (and other) areas in a separate PR if useful.

## Note on the German translation
I'm not a native/fluent German speaker — the `translations/de.json` strings were drafted to the best of my ability (and machine-assisted) but please treat them as a starting point. Happy to update if you or another reviewer can suggest better wording.